### PR TITLE
Added caching and retry policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,9 @@ Options:
 ## License
 
 Public domain. Do whatever you like with this code, no attribution needed.
+
+## To Do
+
+- [ ] GitHub Actions for build+test
+- [ ] GitHub Action to automatically publish trimmed executables as a release
+- [ ] `--dry-run` flag

--- a/RezoningScraper/API.cs
+++ b/RezoningScraper/API.cs
@@ -15,11 +15,10 @@ public static class API
 	/// <returns>An async enumerable of projects (because the API is paginated)</returns>
 	public static async IAsyncEnumerable<Project> GetAllProjects(string jwt, bool useCache = false)
 	{
-
-			IAsyncPolicy<Projects> cachePolicy = useCache
-				? Policy.CacheAsync<Projects>(new CacheManager<Projects>(), TimeSpan.FromHours(1))
-				: Policy.NoOpAsync<Projects>();
-			var client = new HttpClient();
+		IAsyncPolicy<Projects> cachePolicy = useCache
+			? Policy.CacheAsync<Projects>(new CacheManager<Projects>(), TimeSpan.FromHours(1))
+			: Policy.NoOpAsync<Projects>();
+		var client = new HttpClient();
 		string startUrl = $"https://shapeyourcity.ca/api/v2/projects?per_page={ResultsPerPage}";
 
 		string? next = startUrl;

--- a/RezoningScraper/CacheManager.cs
+++ b/RezoningScraper/CacheManager.cs
@@ -1,5 +1,4 @@
 ﻿using Polly.Caching;
-using System.IO.IsolatedStorage;
 using System.Text.Json;
 using System.Security.Cryptography;
 using System.Text;

--- a/RezoningScraper/CacheManager.cs
+++ b/RezoningScraper/CacheManager.cs
@@ -1,0 +1,67 @@
+﻿using Polly.Caching;
+using System.IO.IsolatedStorage;
+using System.Text.Json;
+using System.Security.Cryptography;
+using System.Text;
+using static Spectre.Console.AnsiConsole;
+
+namespace RezoningScraper
+{
+    public class CacheManager<TResult> : IAsyncCacheProvider<TResult>
+    {
+        record CachedRecord<T>(DateTime Ttl, T Record);
+        public async Task PutAsync(string key, TResult value, Ttl ttl, CancellationToken ct, bool continueOnCapturedContext)
+        {
+            using IsolatedStorageFile isoStore = IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Domain | IsolatedStorageScope.Assembly, null, null);
+            using var sha = SHA256.Create();
+            var hashbytes = sha.ComputeHash(Encoding.UTF8.GetBytes(key));
+            var hashstring = new StringBuilder();
+            foreach (var b in hashbytes)
+            {
+                hashstring.Append(b.ToString("X2"));
+            }
+            using var openFile = isoStore.OpenFile(hashstring.ToString(), FileMode.Create, FileAccess.Write);
+            await JsonSerializer.SerializeAsync(openFile, new CachedRecord<TResult>(DateTime.UtcNow + ttl.Timespan, value), cancellationToken: ct);
+            WriteLine($"Completed put cache for {key}");
+        }
+
+        public Task<(bool, TResult)> TryGetAsync(string key, CancellationToken ct, bool continueOnCapturedContext)
+        {
+            using var sha = SHA256.Create();
+            var hashbytes = sha.ComputeHash(Encoding.UTF8.GetBytes(key));
+            var hashstring = new StringBuilder();
+            foreach (var b in hashbytes)
+            {
+                hashstring.Append(b.ToString("X2"));
+            }
+            using IsolatedStorageFile isoStore = IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Domain | IsolatedStorageScope.Assembly, null, null);
+            try
+            {
+                if (!isoStore.FileExists(hashstring.ToString()))
+                {
+                    WriteLine($"No value in cache for {key}");
+                    return Task.FromResult((false, default(TResult)));
+                }
+                using var openFile = isoStore.OpenFile(hashstring.ToString(), FileMode.Open, FileAccess.Read);
+                using var sr = new StreamReader(openFile);
+                var model = JsonSerializer.Deserialize<CachedRecord<TResult>>(sr.ReadToEnd());
+                if (model?.Ttl < DateTime.UtcNow || model is null || model.Record is null)
+                {
+                    WriteLine($"Expired/missing value in cache for {key}");
+                    return Task.FromResult((false, default(TResult)));
+                }
+                else
+                {
+
+                    WriteLine($"Found value in cache for {key}");
+                    return Task.FromResult((true, model.Record));
+                }
+            }
+            catch
+            {
+                WriteLine($"Error on get cache for {key}");
+                return Task.FromResult((false, default(TResult)));
+            }
+        }
+    }
+}

--- a/RezoningScraper/DbHelper.cs
+++ b/RezoningScraper/DbHelper.cs
@@ -44,7 +44,15 @@ CREATE TABLE IF NOT EXISTS
 TokenCache(
     Expiration INTEGER NOT NULL,
     Token TEXT NOT NULL
-);";
+);
+
+CREATE TABLE IF NOT EXISTS
+Cache(
+  Key TEXT PRIMARY KEY,
+  Expiration INTEGER NOT NULL,
+  Value TEXT NOT NULL
+);
+";
         conn.Execute(sql);
     }
 

--- a/RezoningScraper/RezoningScraper.csproj
+++ b/RezoningScraper/RezoningScraper.csproj
@@ -5,7 +5,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<Version>2.1.0.0</Version>
+		<Version>2.2.0.0</Version>
 
 	</PropertyGroup>
 

--- a/RezoningScraper/RezoningScraper.csproj
+++ b/RezoningScraper/RezoningScraper.csproj
@@ -17,6 +17,7 @@
 		<PackageReference Include="AngleSharp" Version="0.16.1" />
 		<PackageReference Include="Dapper" Version="2.0.123" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.0" />
+		<PackageReference Include="Polly" Version="7.2.2" />
 		<PackageReference Include="Spectre.Console" Version="0.42.0" />
 		<PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.14.1" />

--- a/RezoningScraper/TokenHelper.cs
+++ b/RezoningScraper/TokenHelper.cs
@@ -20,7 +20,6 @@ internal static class TokenHelper
         }
         else
         {
-            // TODO: add retries, this page seems unreliable
             IAsyncPolicy<Token> cachePolicy = useCache
                 ? Policy.CacheAsync<Token>(new CacheManager<Token>(), TimeSpan.FromMinutes(1))
                 : Policy.NoOpAsync<Token>();


### PR DESCRIPTION
Hi, I put some retry and caching semantics on your web requests using Polly. The gist of it is that all web requests now retry thrice and they will also cache their responses. The cache is based on what the uri is, since all requests are GETs, and the retention period is variable. Caching uses the local temp directory, with a file scoped to only this user/process, so it persists between invocations but should not be accessible by other processes. Caching only occurs if `--use-cache` is on. Retry always happens.

![image](https://user-images.githubusercontent.com/1548193/144199402-7dbddec9-b71e-4a90-be5f-035bab7431c5.png)
