### PR TITLE
Upgrade to Claude Haiku 4.5

### DIFF
--- a/src/summarizer.rs
+++ b/src/summarizer.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 use crate::models::Project;
 
-const MODEL_ANTHROPIC: &str = "claude-3-5-haiku-20241022";
+const MODEL_ANTHROPIC: &str = "claude-haiku-4-5-20251001";
 
 /// Convert HTML to Markdown, ignoring images and not including URLs
 pub fn html_to_markdown(html: &str) -> String {


### PR DESCRIPTION
## Summary

Claude 3.5 Haiku has been discontinued, so this upgrades the summarizer model from `claude-3-5-haiku-20241022` to `claude-haiku-4-5-20251001`.

Tested with the `claude` example and it works fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)