### PR TITLE
Make scraper failures observable again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,163 +3,6 @@
 version = 4
 
 [[package]]
-name = "actix-codec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-core",
- "futures-sink",
- "memchr",
- "pin-project-lite",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "actix-http"
-version = "3.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7926860314cbe2fb5d1f13731e387ab43bd32bca224e82e6e2db85de0a3dba49"
-dependencies = [
- "actix-codec",
- "actix-rt",
- "actix-service",
- "actix-utils",
- "bitflags",
- "bytes",
- "bytestring",
- "derive_more 2.1.1",
- "encoding_rs",
- "foldhash 0.1.5",
- "futures-core",
- "http 0.2.12",
- "httparse",
- "httpdate",
- "itoa",
- "language-tags",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "smallvec",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "actix-router"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
-dependencies = [
- "bytestring",
- "cfg-if",
- "http 0.2.12",
- "regex-lite",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "actix-rt"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63"
-dependencies = [
- "futures-core",
- "tokio",
-]
-
-[[package]]
-name = "actix-server"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
-dependencies = [
- "actix-rt",
- "actix-service",
- "actix-utils",
- "futures-core",
- "futures-util",
- "mio",
- "socket2 0.5.10",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "actix-service"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "actix-utils"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
-dependencies = [
- "local-waker",
- "pin-project-lite",
-]
-
-[[package]]
-name = "actix-web"
-version = "4.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1654a77ba142e37f049637a3e5685f864514af11fcbc51cb51eb6596afe5b8d6"
-dependencies = [
- "actix-codec",
- "actix-http",
- "actix-router",
- "actix-rt",
- "actix-server",
- "actix-service",
- "actix-utils",
- "bytes",
- "bytestring",
- "cfg-if",
- "derive_more 2.1.1",
- "encoding_rs",
- "foldhash 0.1.5",
- "futures-core",
- "futures-util",
- "impl-more",
- "itoa",
- "language-tags",
- "log",
- "mime",
- "once_cell",
- "pin-project-lite",
- "regex-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "smallvec",
- "socket2 0.6.1",
- "time",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,7 +176,7 @@ dependencies = [
  "atrium-common",
  "atrium-xrpc",
  "chrono",
- "http 1.4.0",
+ "http",
  "ipld-core",
  "langtag",
  "regex",
@@ -366,7 +209,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "944b35cc08732d40ddbb3356be9e38d11aed4b4c40c33f5b0f235e0650eff296"
 dependencies = [
- "http 1.4.0",
+ "http",
  "serde",
  "serde_html_form",
  "serde_json",
@@ -456,21 +299,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
-]
-
-[[package]]
 name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,12 +321,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,15 +339,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
 dependencies = [
  "core2",
-]
-
-[[package]]
-name = "block2"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
-dependencies = [
- "objc2",
 ]
 
 [[package]]
@@ -576,15 +389,6 @@ name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
-
-[[package]]
-name = "bytestring"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289"
-dependencies = [
- "bytes",
-]
 
 [[package]]
 name = "cc"
@@ -961,26 +765,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "debugid"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
-dependencies = [
- "serde",
- "uuid",
-]
-
-[[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,16 +818,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dispatch2"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
-dependencies = [
- "bitflags",
- "objc2",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +826,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dogstatsd"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eb371fd367d96238721881622f7f36878ca4e2ff5db7ad794651a439083509f"
+dependencies = [
+ "chrono",
+ "retry",
 ]
 
 [[package]]
@@ -1243,18 +1027,6 @@ name = "find-msvc-tools"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
-
-[[package]]
-name = "findshlibs"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
-dependencies = [
- "cc",
- "lazy_static",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "flate2"
@@ -1482,12 +1254,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,7 +1264,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http",
  "indexmap 2.13.0",
  "slab",
  "tokio",
@@ -1571,17 +1337,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hostname"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
-dependencies = [
- "cfg-if",
- "libc",
- "windows-link",
-]
-
-[[package]]
 name = "html2md"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,17 +1376,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -1647,7 +1391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -1658,7 +1402,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http",
  "http-body",
  "pin-project-lite",
 ]
@@ -1668,12 +1412,6 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
@@ -1686,7 +1424,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.0",
+ "http",
  "http-body",
  "httparse",
  "itoa",
@@ -1703,7 +1441,7 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.4.0",
+ "http",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1740,14 +1478,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http",
  "http-body",
  "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1928,12 +1666,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
-name = "impl-more"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,12 +1826,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "language-tags"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,12 +1875,6 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
-
-[[package]]
-name = "local-waker"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
 name = "lock_api"
@@ -2304,7 +2024,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2384,18 +2103,6 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
 
 [[package]]
 name = "nom"
@@ -2479,174 +2186,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2-cloud-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
-dependencies = [
- "bitflags",
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-data"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags",
- "dispatch2",
- "objc2",
-]
-
-[[package]]
-name = "objc2-core-graphics"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
-dependencies = [
- "bitflags",
- "dispatch2",
- "objc2",
- "objc2-core-foundation",
- "objc2-io-surface",
-]
-
-[[package]]
-name = "objc2-core-image"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-location"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-text"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
-dependencies = [
- "bitflags",
- "objc2",
- "objc2-core-foundation",
- "objc2-core-graphics",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
-name = "objc2-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
-dependencies = [
- "bitflags",
- "block2",
- "libc",
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-io-surface"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
-dependencies = [
- "bitflags",
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-quartz-core"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
-dependencies = [
- "bitflags",
- "objc2",
- "objc2-core-foundation",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-ui-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
-dependencies = [
- "bitflags",
- "block2",
- "objc2",
- "objc2-cloud-kit",
- "objc2-core-data",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-core-image",
- "objc2-core-location",
- "objc2-core-text",
- "objc2-foundation",
- "objc2-quartz-core",
- "objc2-user-notifications",
-]
-
-[[package]]
-name = "objc2-user-notifications"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2719,22 +2258,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_info"
-version = "3.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
-dependencies = [
- "android_system_properties",
- "log",
- "nix",
- "objc2",
- "objc2-foundation",
- "objc2-ui-kit",
- "serde",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2774,15 +2297,6 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -3028,7 +2542,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -3066,7 +2580,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3253,12 +2767,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-lite"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
-
-[[package]]
 name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3272,10 +2780,8 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
- "http 1.4.0",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -3314,7 +2820,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.4.0",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -3346,6 +2852,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "retry"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cab9bd343c737660e523ee69f788018f3db686d537d2fd0f99c9f747c1bda4f"
+dependencies = [
+ "rand 0.9.2",
+]
+
+[[package]]
 name = "rezoning-scraper"
 version = "3.2.1"
 dependencies = [
@@ -3355,6 +2870,7 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
+ "dogstatsd",
  "genai",
  "html2md",
  "image",
@@ -3364,7 +2880,6 @@ dependencies = [
  "reqwest 0.13.1",
  "rusqlite",
  "scraper",
- "sentry",
  "serde",
  "serde_json",
  "tokio",
@@ -3404,12 +2919,6 @@ dependencies = [
  "smallvec",
  "sqlite-wasm-rs",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -3651,139 +3160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
-name = "sentry"
-version = "0.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f925d575b468e88b079faf590a8dd0c9c99e2ec29e9bab663ceb8b45056312f"
-dependencies = [
- "httpdate",
- "native-tls",
- "reqwest 0.12.28",
- "sentry-actix",
- "sentry-anyhow",
- "sentry-backtrace",
- "sentry-contexts",
- "sentry-core",
- "sentry-debug-images",
- "sentry-panic",
- "sentry-tracing",
- "tokio",
- "ureq",
-]
-
-[[package]]
-name = "sentry-actix"
-version = "0.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18bac0f6b8621fa0f85e298901e51161205788322e1a995e3764329020368058"
-dependencies = [
- "actix-http",
- "actix-web",
- "bytes",
- "futures-util",
- "sentry-core",
-]
-
-[[package]]
-name = "sentry-anyhow"
-version = "0.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e45993dc8981e7fb5d9b7f701f65ca5c9fb0390263e47f612f30bea3d35fac"
-dependencies = [
- "anyhow",
- "sentry-backtrace",
- "sentry-core",
-]
-
-[[package]]
-name = "sentry-backtrace"
-version = "0.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb1ef7534f583af20452b1b1bf610a60ed9c8dd2d8485e7bd064efc556a78fb"
-dependencies = [
- "backtrace",
- "regex",
- "sentry-core",
-]
-
-[[package]]
-name = "sentry-contexts"
-version = "0.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd6be899d9938390b6d1ec71e2f53bd9e57b6a9d8b1d5b049e5c364e7da9078"
-dependencies = [
- "hostname",
- "libc",
- "os_info",
- "rustc_version",
- "sentry-core",
- "uname",
-]
-
-[[package]]
-name = "sentry-core"
-version = "0.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ab054c34b87f96c3e4701bea1888317cde30cc7e4a6136d2c48454ab96661c"
-dependencies = [
- "rand 0.9.2",
- "sentry-types",
- "serde",
- "serde_json",
- "url",
-]
-
-[[package]]
-name = "sentry-debug-images"
-version = "0.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5637ec550dc6f8c49a711537950722d3fc4baa6fd433c371912104eaff31e2a5"
-dependencies = [
- "findshlibs",
- "sentry-core",
-]
-
-[[package]]
-name = "sentry-panic"
-version = "0.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f02c7162f7b69b8de872b439d4696dc1d65f80b13ddd3c3831723def4756b63"
-dependencies = [
- "sentry-backtrace",
- "sentry-core",
-]
-
-[[package]]
-name = "sentry-tracing"
-version = "0.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1dd47df349a80025819f3d25c3d2f751df705d49c65a4cdc0f130f700972a48"
-dependencies = [
- "bitflags",
- "sentry-backtrace",
- "sentry-core",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "sentry-types"
-version = "0.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eecbd63e9d15a26a40675ed180d376fcb434635d2e33de1c24003f61e3e2230d"
-dependencies = [
- "debugid",
- "hex",
- "rand 0.9.2",
- "serde",
- "serde_json",
- "thiserror 2.0.17",
- "time",
- "url",
- "uuid",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3949,16 +3325,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -4254,7 +3620,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4340,7 +3706,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http",
  "http-body",
  "http-body-util",
  "iri-string",
@@ -4370,7 +3736,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4394,16 +3759,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
-dependencies = [
- "tracing-core",
 ]
 
 [[package]]
@@ -4422,15 +3777,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "uname"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "unicase"
@@ -4481,35 +3827,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ureq"
-version = "3.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
-dependencies = [
- "base64",
- "der",
- "log",
- "native-tls",
- "percent-encoding",
- "rustls-pki-types",
- "ureq-proto",
- "utf-8",
- "webpki-root-certs",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
-dependencies = [
- "base64",
- "http 1.4.0",
- "httparse",
- "log",
-]
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4519,7 +3836,6 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -4548,7 +3864,6 @@ checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
- "serde_core",
  "wasm-bindgen",
 ]
 
@@ -4562,12 +3877,6 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-ext"
@@ -4740,22 +4049,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4763,12 +4056,6 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ rusqlite = { version = "0.38.0", features = ["bundled"] }
 reqwest = { version = "0.13.1", features = ["json"] }
 indicatif = "0.18.3"
 colored = "3.0.0"
+dogstatsd = "0.12.4"
 tokio = { version = "1", features = ["full"] }
 bsky-sdk = "0.1.23"
 html2md = "0.2.15"
 genai = "0.5.0"
 itertools = "0.14.0"
-sentry = { version = "0.46.1", features = ["anyhow"] }
 image = "0.25.9"
 
 # Force vendored OpenSSL on Linux to make building for musl easier

--- a/README.md
+++ b/README.md
@@ -40,29 +40,13 @@ Options:
 
 ## Monitoring
 
-The scraper reports each run to a local Datadog Agent through DogStatsD. It
-sends:
-
-- the `rezoning_scraper.run` service check
-- `rezoning_scraper.queue.depth`, tagged by queue
-- `rezoning_scraper.dead_letter.depth`, tagged by queue
-- structured error logs with `service:rezoning-scraper` and `env:production`
-
-Set `DD_SERVICE`, `DD_ENV`, or `DOGSTATSD_ADDRESS` to override those defaults.
-
-Create a Datadog service check monitor for `rezoning_scraper.run`. Alert on one
-critical check and on 20 hours without data, then add an email address to the
-notification message. The no-data alert catches a timer or host failure as well
-as errors reported by the scraper.
-
-Test the whole path without scraping or posting anything:
+The scraper reports run status and queue depth to a local Datadog Agent. It
+also exits non-zero and writes a structured log when anything fails.
 
 ```console
 rezoning-scraper --monitoring-test critical
 rezoning-scraper --monitoring-test ok
 ```
-
-Wait for the critical notification before sending the OK status.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,39 @@ Options:
           Use cached API responses (up to 1 hour old) when available
       --skip-update-db
           Skip updating the local database (useful for testing)
+      --monitoring-test <MONITORING_TEST>
+          Send a test status to monitoring without running the scraper [possible values: ok, critical]
   -h, --help
           Print help
   -V, --version
           Print version
 ```
+
+## Monitoring
+
+The scraper reports each run to a local Datadog Agent through DogStatsD. It
+sends:
+
+- the `rezoning_scraper.run` service check
+- `rezoning_scraper.queue.depth`, tagged by queue
+- `rezoning_scraper.dead_letter.depth`, tagged by queue
+- structured error logs with `service:rezoning-scraper` and `env:production`
+
+Set `DD_SERVICE`, `DD_ENV`, or `DOGSTATSD_ADDRESS` to override those defaults.
+
+Create a Datadog service check monitor for `rezoning_scraper.run`. Alert on one
+critical check and on 20 hours without data, then add an email address to the
+notification message. The no-data alert catches a timer or host failure as well
+as errors reported by the scraper.
+
+Test the whole path without scraping or posting anything:
+
+```console
+rezoning-scraper --monitoring-test critical
+rezoning-scraper --monitoring-test ok
+```
+
+Wait for the critical notification before sending the OK status.
 
 ## License
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -240,7 +240,7 @@ mod tests {
             links: Default::default(),
         };
 
-        db.upsert_projects(&[project1.clone()])?;
+        db.upsert_projects(std::slice::from_ref(&project1))?;
         let retrieved = db.get_project("foo")?;
         assert_eq!(retrieved.project_type, "first");
 
@@ -249,7 +249,7 @@ mod tests {
             ..project1
         };
 
-        db.upsert_projects(&[project2.clone()])?;
+        db.upsert_projects(std::slice::from_ref(&project2))?;
         let retrieved = db.get_project("foo")?;
         assert_eq!(retrieved.project_type, "second");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,14 +2,15 @@ use anyhow::{anyhow, Result};
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use chrono::{DateTime, TimeZone, Utc};
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use colored::Colorize;
 use db::{Database, Token};
 use indicatif::ProgressBar;
 use models::{Project, Projects, SummarizedProject};
+use monitoring::{Monitoring, ServiceCheckStatus};
 use queue::Queue;
 use scraper::{Html, Selector};
-use sentry::integrations::anyhow::capture_anyhow;
+use serde_json::json;
 use serde_json::Value;
 use std::time::Duration;
 use summarizer::project_to_tweet;
@@ -18,10 +19,17 @@ use tokio::time::sleep;
 mod bluesky;
 mod db;
 mod models;
+mod monitoring;
 mod queue;
 mod summarizer;
 
 const MAX_MESSAGE_PROCESSING_ATTEMPTS: i32 = 3;
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum MonitoringTestStatus {
+    Ok,
+    Critical,
+}
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -54,33 +62,72 @@ struct Args {
 
     #[arg(long, help = "Skip updating the local database (useful for testing)")]
     skip_update_db: bool,
+
+    #[arg(
+        long,
+        value_enum,
+        help = "Send a test status to monitoring without running the scraper"
+    )]
+    monitoring_test: Option<MonitoringTestStatus>,
 }
 
 fn main() -> Result<()> {
-    // Sentry needs to initialized before the tokio runtime
-    let _guard = sentry::init((
-        "https://b9aa3a714ea10fe4c30c0905fbc8db11@sentry-intake.datadoghq.com/1",
-        sentry::ClientOptions {
-            release: sentry::release_name!(),
-            attach_stacktrace: true,
-            ..Default::default()
-        },
-    ));
+    let args = Args::parse();
+    let monitoring = Monitoring::new()?;
 
-    if let Err(e) = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()?
-        .block_on(async_main())
-    {
-        capture_anyhow(&e);
+    if let Some(status) = args.monitoring_test {
+        return test_monitoring(&monitoring, status);
     }
 
-    Ok(())
+    let result = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(async_main(args, &monitoring));
+
+    match result {
+        Ok(()) => monitoring.service_check(
+            ServiceCheckStatus::Ok,
+            "Rezoning scraper completed successfully",
+        ),
+        Err(error) => {
+            monitoring.error("Rezoning scraper run failed", &error, &[]);
+            if let Err(reporting_error) = monitoring.service_check(
+                ServiceCheckStatus::Critical,
+                &format!("Rezoning scraper failed: {error:#}"),
+            ) {
+                monitoring.error(
+                    "Failed to report scraper failure to DogStatsD",
+                    &reporting_error,
+                    &[],
+                );
+            }
+            Err(error)
+        }
+    }
 }
 
-async fn async_main() -> Result<()> {
-    let args = Args::parse();
+fn test_monitoring(monitoring: &Monitoring, status: MonitoringTestStatus) -> Result<()> {
+    match status {
+        MonitoringTestStatus::Ok => monitoring.service_check(
+            ServiceCheckStatus::Ok,
+            "Manual monitoring test: everything is OK",
+        ),
+        MonitoringTestStatus::Critical => {
+            let error = anyhow!("deliberate monitoring test failure");
+            monitoring.error(
+                "Manual monitoring test",
+                &error,
+                &[("monitoring_test", json!(true))],
+            );
+            monitoring.service_check(
+                ServiceCheckStatus::Critical,
+                "Manual monitoring test: deliberate failure",
+            )
+        }
+    }
+}
 
+async fn async_main(args: Args, monitoring: &Monitoring) -> Result<()> {
     println!(
         "{}",
         format!("Rezoning Scraper v{}", env!("CARGO_PKG_VERSION"))
@@ -222,6 +269,8 @@ async fn async_main() -> Result<()> {
         }
     }
 
+    let mut processing_failures = 0;
+
     // Process LLM queue
     {
         let depth = llm_queue.depth(&db)?;
@@ -244,8 +293,21 @@ async fn async_main() -> Result<()> {
                         bsky_queue.push(&db, summarized)?;
                     }
                     Err(e) => {
-                        eprintln!("Error processing project: {}", e);
                         message.attempts += 1;
+                        let dead_lettered = message.attempts >= MAX_MESSAGE_PROCESSING_ATTEMPTS;
+                        monitoring.error(
+                            "Failed to summarize project",
+                            &e,
+                            &[
+                                ("queue", json!("llm_queue")),
+                                ("attempt", json!(message.attempts)),
+                                ("max_attempts", json!(MAX_MESSAGE_PROCESSING_ATTEMPTS)),
+                                ("dead_lettered", json!(dead_lettered)),
+                                ("project_id", json!(project.id)),
+                            ],
+                        );
+                        processing_failures += 1;
+
                         if message.attempts < MAX_MESSAGE_PROCESSING_ATTEMPTS {
                             llm_queue.push_message(&db, &message)?;
                         } else {
@@ -254,9 +316,6 @@ async fn async_main() -> Result<()> {
                                 message.attempts
                             );
                             llm_queue.push_to_dead_letter(&db, &message, &e.to_string())?;
-                            capture_anyhow(&e.context(
-                                "Failed to summarize project, moving to dead letter queue",
-                            ));
                         }
                     }
                 }
@@ -267,7 +326,8 @@ async fn async_main() -> Result<()> {
 
     // Post to Slack if configured
     if let Some(webhook_url) = args.slack_webhook_url {
-        process_slack_queue(&slack_queue, &mut db, &webhook_url).await?;
+        processing_failures +=
+            process_slack_queue(monitoring, &slack_queue, &mut db, &webhook_url).await?;
     }
 
     // Post to Bluesky if configured
@@ -287,8 +347,21 @@ async fn async_main() -> Result<()> {
                 )
                 .await
                 {
-                    eprintln!("Error posting to Bluesky: {}", e);
                     message.attempts += 1;
+                    let dead_lettered = message.attempts >= MAX_MESSAGE_PROCESSING_ATTEMPTS;
+                    monitoring.error(
+                        "Failed to post project to Bluesky",
+                        &e,
+                        &[
+                            ("queue", json!("bluesky_post_queue")),
+                            ("attempt", json!(message.attempts)),
+                            ("max_attempts", json!(MAX_MESSAGE_PROCESSING_ATTEMPTS)),
+                            ("dead_lettered", json!(dead_lettered)),
+                            ("project_id", json!(message.payload.project.id)),
+                        ],
+                    );
+                    processing_failures += 1;
+
                     if message.attempts < MAX_MESSAGE_PROCESSING_ATTEMPTS {
                         bsky_queue.push_message(&db, &message)?;
                     } else {
@@ -297,9 +370,6 @@ async fn async_main() -> Result<()> {
                             message.attempts
                         );
                         bsky_queue.push_to_dead_letter(&db, &message, &e.to_string())?;
-                        capture_anyhow(
-                            &e.context("Failed to post to Bluesky, moving to dead letter queue"),
-                        );
                     }
                 }
 
@@ -310,16 +380,26 @@ async fn async_main() -> Result<()> {
         }
     }
 
+    report_queue_depths(monitoring, &db, &llm_queue, &slack_queue, &bsky_queue)?;
+
+    if processing_failures > 0 {
+        return Err(anyhow!(
+            "run completed with {processing_failures} processing failure(s)"
+        ));
+    }
+
     Ok(())
 }
 
 async fn process_slack_queue(
+    monitoring: &Monitoring,
     slack_queue: &Queue<SummarizedProject>,
     db: &mut Database,
     webhook_url: &str,
-) -> Result<()> {
+) -> Result<usize> {
     let depth = slack_queue.depth(db)?;
     let mut processed = 0;
+    let mut failures = 0;
 
     // process everything currently in the queue
     while processed < depth {
@@ -328,19 +408,64 @@ async fn process_slack_queue(
             if let Err(e) = post_to_slack(webhook_url, slack_message).await {
                 message.attempts += 1;
                 message.last_attempt = Some(Utc::now());
-                eprintln!("Error posting to Slack: {}", e);
+                let dead_lettered = message.attempts >= MAX_MESSAGE_PROCESSING_ATTEMPTS;
+                monitoring.error(
+                    "Failed to post project to Slack",
+                    &e,
+                    &[
+                        ("queue", json!("slack_post_queue")),
+                        ("attempt", json!(message.attempts)),
+                        ("max_attempts", json!(MAX_MESSAGE_PROCESSING_ATTEMPTS)),
+                        ("dead_lettered", json!(dead_lettered)),
+                        ("project_id", json!(message.payload.project.id)),
+                    ],
+                );
+                failures += 1;
+
                 if message.attempts < MAX_MESSAGE_PROCESSING_ATTEMPTS {
                     slack_queue.push_message(db, &message)?;
                 } else {
-                    eprintln!("Message failed,  moving to dead letter queue: {}", &e);
+                    eprintln!("Message failed, moving to dead letter queue: {e}");
                     slack_queue.push_to_dead_letter(db, &message, &e.to_string())?;
-                    capture_anyhow(
-                        &e.context("Failed to post to Slack, moving to dead letter queue"),
-                    );
                 }
             }
         }
         processed += 1;
+    }
+
+    Ok(failures)
+}
+
+fn report_queue_depths(
+    monitoring: &Monitoring,
+    db: &Database,
+    llm_queue: &Queue<Project>,
+    slack_queue: &Queue<SummarizedProject>,
+    bsky_queue: &Queue<SummarizedProject>,
+) -> Result<()> {
+    for (name, depth, dead_letter_depth) in [
+        (
+            "llm_queue",
+            llm_queue.depth(db)?,
+            llm_queue.dead_letter_depth(db)?,
+        ),
+        (
+            "slack_post_queue",
+            slack_queue.depth(db)?,
+            slack_queue.dead_letter_depth(db)?,
+        ),
+        (
+            "bluesky_post_queue",
+            bsky_queue.depth(db)?,
+            bsky_queue.dead_letter_depth(db)?,
+        ),
+    ] {
+        monitoring.gauge("rezoning_scraper.queue.depth", depth, &[("queue", name)])?;
+        monitoring.gauge(
+            "rezoning_scraper.dead_letter.depth",
+            dead_letter_depth,
+            &[("queue", name)],
+        )?;
     }
 
     Ok(())

--- a/src/monitoring.rs
+++ b/src/monitoring.rs
@@ -1,0 +1,125 @@
+use anyhow::{Context, Result};
+use dogstatsd::{
+    Client, OptionsBuilder, ServiceCheckOptions, ServiceStatus as DogStatsdServiceStatus,
+};
+use serde_json::{json, Value};
+
+const DEFAULT_DOGSTATSD_ADDRESS: &str = "127.0.0.1:8125";
+const SERVICE_CHECK_NAME: &str = "rezoning_scraper.run";
+
+#[derive(Clone, Copy, Debug)]
+pub enum ServiceCheckStatus {
+    Ok,
+    Critical,
+}
+
+pub struct Monitoring {
+    client: Client,
+    service: String,
+    environment: String,
+}
+
+impl Monitoring {
+    pub fn new() -> Result<Self> {
+        let address = std::env::var("DOGSTATSD_ADDRESS")
+            .unwrap_or_else(|_| DEFAULT_DOGSTATSD_ADDRESS.to_string());
+        let service =
+            std::env::var("DD_SERVICE").unwrap_or_else(|_| "rezoning-scraper".to_string());
+        let environment = std::env::var("DD_ENV").unwrap_or_else(|_| "production".to_string());
+
+        let mut options = OptionsBuilder::new();
+        options
+            .to_addr(address)
+            .default_tag(format!("service:{service}"))
+            .default_tag(format!("env:{environment}"));
+        let client = Client::new(options.build()).context("failed to create DogStatsD client")?;
+
+        Ok(Self {
+            client,
+            service,
+            environment,
+        })
+    }
+
+    pub fn service_check(&self, status: ServiceCheckStatus, message: &str) -> Result<()> {
+        let message = sanitize_datagram_value(message, 500);
+        let options = ServiceCheckOptions {
+            message: Some(&message),
+            ..Default::default()
+        };
+        let status = match status {
+            ServiceCheckStatus::Ok => DogStatsdServiceStatus::OK,
+            ServiceCheckStatus::Critical => DogStatsdServiceStatus::Critical,
+        };
+
+        self.client
+            .service_check(SERVICE_CHECK_NAME, status, &[] as &[&str], Some(options))
+            .context("failed to send DogStatsD service check")
+    }
+
+    pub fn gauge(&self, name: &str, value: i64, tags: &[(&str, &str)]) -> Result<()> {
+        let tags = tags
+            .iter()
+            .map(|(key, value)| format!("{key}:{value}"))
+            .collect::<Vec<_>>();
+
+        self.client
+            .gauge(name, value.to_string(), &tags)
+            .with_context(|| format!("failed to send DogStatsD gauge {name}"))
+    }
+
+    pub fn error(&self, message: &str, error: &anyhow::Error, fields: &[(&str, Value)]) {
+        let mut event = json!({
+            "status": "error",
+            "service": self.service,
+            "env": self.environment,
+            "message": message,
+            "error": {
+                "kind": "application_error",
+                "message": format!("{error:#}"),
+            },
+        });
+
+        let object = event
+            .as_object_mut()
+            .expect("the monitoring event is always a JSON object");
+        for (key, value) in fields {
+            object.insert((*key).to_string(), value.clone());
+        }
+
+        // systemd treats the <3> prefix as the native journald error priority
+        // and strips it from the stored message.
+        eprintln!("<3>{event}");
+    }
+}
+
+fn sanitize_datagram_value(value: &str, max_bytes: usize) -> String {
+    let sanitized = value.replace(['\n', '\r', '|'], " ");
+    if sanitized.len() <= max_bytes {
+        return sanitized;
+    }
+
+    let mut end = max_bytes;
+    while !sanitized.is_char_boundary(end) {
+        end -= 1;
+    }
+    sanitized[..end].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitizes_service_check_messages() {
+        assert_eq!(
+            sanitize_datagram_value("bad|thing\nhappened", 500),
+            "bad thing happened"
+        );
+    }
+
+    #[test]
+    fn truncates_service_check_messages_at_a_utf8_boundary() {
+        assert_eq!(sanitize_datagram_value("abc😀def", 6), "abc");
+    }
+}

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -40,6 +40,15 @@ where
         Ok(count)
     }
 
+    pub fn dead_letter_depth(&self, conn: &Connection) -> Result<i64> {
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM DeadLetterQueue WHERE queue_name = ?1",
+            params![self.name],
+            |row| row.get(0),
+        )?;
+        Ok(count)
+    }
+
     pub fn push(&self, conn: &Connection, item: T) -> Result<i64> {
         let msg = QueueMessage {
             id: 0, // Will be set by SQLite
@@ -285,6 +294,7 @@ mod tests {
         let message = queue.pop(&mut conn)?.unwrap();
 
         queue.push_to_dead_letter(&conn, &message, "processing failed")?;
+        assert_eq!(queue.dead_letter_depth(&conn)?, 1);
 
         // Test popping from dead letter queue
         let (dead_msg, error) = queue.pop_from_dead_letter(&mut conn)?.unwrap();
@@ -293,6 +303,7 @@ mod tests {
 
         // Verify dead letter queue is empty
         assert!(queue.pop_from_dead_letter(&mut conn)?.is_none());
+        assert_eq!(queue.dead_letter_depth(&conn)?, 0);
 
         Ok(())
     }

--- a/src/summarizer.rs
+++ b/src/summarizer.rs
@@ -89,7 +89,7 @@ mod tests {
         handlers.insert("img".to_string(), Box::new(IgnoreHandlerFactory));
         handlers.insert("a".to_string(), Box::new(TextOnlyHandlerFactory));
 
-        let md = html2md::parse_html_custom(&description, &handlers);
+        let md = html2md::parse_html_custom(description, &handlers);
 
         let expected = "Matthew Cheng Architect Inc. has applied to the City of Vancouver for permission to develop the following on this site:
 


### PR DESCRIPTION
The scraper was failing for a bit due to an invalid API key, and I didn't notice. Something was broken with the Sentry-to-Datadog flow so no events appeared in Error Tracking.

This replaces that setup with the `dogstatsd` client and makes failures visible on the first attempt:

- emit a `rezoning_scraper.run` service check after every run
- exit non-zero when queued work fails, while preserving the existing retries
- write structured error logs at native journald error priority
- report active and dead-letter queue depths as gauges
- add `--monitoring-test critical|ok` for an end-to-end alert test without scraping or posting
- document a monitor that alerts on critical status or 20 hours without data

## Testing

- captured the critical and OK DogStatsD packets locally
- ran the release binary through a temporary systemd unit
- confirmed journald stored the test error at priority 3 with its JSON fields
- reset the service check to OK and removed the temporary binary